### PR TITLE
More compatible Delegate with CoreCLR. Fixes #1.

### DIFF
--- a/src/NonBlockingDictionary/ConcurrentDictionary/DictionaryImpl`2.cs
+++ b/src/NonBlockingDictionary/ConcurrentDictionary/DictionaryImpl`2.cs
@@ -21,9 +21,8 @@ namespace NonBlocking
                     GetMethod("CreateRef", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static).
                     MakeGenericMethod(new Type[] { typeof(TKey), typeof(TValue) });
 
-                var del = (Func<ConcurrentDictionary<TKey, TValue>, int, DictionaryImpl<TKey, TValue>>)Delegate.CreateDelegate(
-                    typeof(Func<ConcurrentDictionary<TKey, TValue>, int, DictionaryImpl<TKey, TValue>>),
-                    method);
+                var del = (Func<ConcurrentDictionary<TKey, TValue>, int, DictionaryImpl<TKey, TValue>>)method
+                    .CreateDelegate(typeof(Func<ConcurrentDictionary<TKey, TValue>, int, DictionaryImpl<TKey, TValue>>));
 
                 var result = del(topDict, capacity);
                 CreateRefUnsafe = del;


### PR DESCRIPTION
I'm by no means expert at CoreCLR yet but I believe this fixes the missing `Delegate.CreateDelegate` issue with CoreCLR. :runner: with :scissors: 
