### PR TITLE
Avoid boxing when value is a primitive that can be written atomically

### DIFF
--- a/BenchmarksCore/Program.cs
+++ b/BenchmarksCore/Program.cs
@@ -56,11 +56,14 @@ namespace NonBlockingTests
             WriteBenchRndNB();
             WriteBenchRndCD();
 
+            WriteBenchRndNBint();
+            WriteBenchRndCDint();
+
             ///////////////////////
             // degenerate cases
 
-            //SingleThreadedSequentialAddWithGapsNB();
             //SingleThreadedSequentialAddWithGapsCD();
+            //SingleThreadedSequentialAddWithGapsNB();
 
             //ChurnConcurrent();
 
@@ -396,6 +399,41 @@ namespace NonBlockingTests
 
             RunBench(benchmarkName, act);
         }
+
+        private static void WriteBenchRndNBint()
+        {
+            var dict = new NonBlocking.ConcurrentDictionary<int, int>();
+
+            var benchmarkName = "======== Random Write NonBlocking 1M int->int Ops/sec:";
+
+            Action<int, int> act = (i, threadBias) =>
+            {
+                // get some random index in [0, 1000000]
+                int randomIndex = GetRandomIndex(i, threadBias, 1000000);
+                dict[randomIndex] = 42;
+                dict[randomIndex] = 24;
+            };
+
+            RunBench(benchmarkName, act);
+        }
+
+        private static void WriteBenchRndCDint()
+        {
+            var dict = new Concurrent.ConcurrentDictionary<int, int>();
+
+            var benchmarkName = "======== Random Write Concurrent 1M int->int Ops/sec:";
+
+            Action<int, int> act = (i, threadBias) =>
+            {
+                // get some random index in [0, 1000000]
+                int randomIndex = GetRandomIndex(i, threadBias, 1000000);
+                dict[randomIndex] = 42;
+                dict[randomIndex] = 24;
+            };
+
+            RunBench(benchmarkName, act);
+        }
+
 
         private static long RunBenchmark(Action<int, int> action, int threads, int time)
         {

--- a/src/NonBlocking/ConcurrentDictionary/ConcurrentDictionary.cs
+++ b/src/NonBlocking/ConcurrentDictionary/ConcurrentDictionary.cs
@@ -328,7 +328,7 @@ namespace NonBlocking
         public bool Remove(TKey key)
         {
             TValue oldVal = default;
-            return _table.RemoveIfMatch(key, ref oldVal, ValueMatch.NotNullOrDead);
+            return _table.RemoveIfMatch(key, ref oldVal, ValueMatch.Any);
         }
 
         /// <summary>

--- a/src/NonBlocking/ConcurrentDictionary/ConcurrentDictionary.cs
+++ b/src/NonBlocking/ConcurrentDictionary/ConcurrentDictionary.cs
@@ -328,11 +328,8 @@ namespace NonBlocking
         /// (Nothing in Visual Basic).</exception>
         public bool Remove(TKey key)
         {
-            object oldValObj = null;
-            var found = _table.PutIfMatch(key, TOMBSTONE, ref oldValObj, ValueMatch.NotNullOrDead);
-            Debug.Assert(!(oldValObj is Prime));
-
-            return found;
+            TValue oldVal = default;
+            return _table.RemoveIfMatch(key, ref oldVal, ValueMatch.NotNullOrDead);
         }
 
         /// <summary>
@@ -349,22 +346,8 @@ namespace NonBlocking
         /// (Nothing in Visual Basic).</exception>
         public bool TryRemove(TKey key, out TValue value)
         {
-            object oldValObj = null;
-            var found = _table.PutIfMatch(key, TOMBSTONE, ref oldValObj, ValueMatch.NotNullOrDead);
-
-            Debug.Assert(!(oldValObj is Prime));
-            Debug.Assert(found ^ oldValObj == null);
-
-            if (!found)
-            {
-                value = default(TValue);
-            }
-            else
-            {
-                value = FromObjectValue(oldValObj);
-            }
-
-            return found;
+            value = default;
+            return _table.RemoveIfMatch(key, ref value, ValueMatch.NotNullOrDead);
         }
 
         /// <summary>
@@ -588,8 +571,8 @@ namespace NonBlocking
         /// name="keyValuePair"/> is a null reference (Nothing in Visual Basic).</exception>
         bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair)
         {
-            object oldValObj = ToObjectValue(keyValuePair.Value);
-            return _table.PutIfMatch(keyValuePair.Key, TOMBSTONE, ref oldValObj, ValueMatch.OldValue);
+            TValue oldVal = keyValuePair.Value;
+            return _table.RemoveIfMatch(keyValuePair.Key, ref oldVal, ValueMatch.OldValue);
         }
 
         bool IDictionary.IsReadOnly => false;

--- a/src/NonBlocking/ConcurrentDictionary/ConcurrentDictionary.cs
+++ b/src/NonBlocking/ConcurrentDictionary/ConcurrentDictionary.cs
@@ -309,9 +309,8 @@ namespace NonBlocking
         /// contains too many elements.</exception>
         public bool TryAdd(TKey key, TValue value)
         {
-            object oldValObj = null;
-            object newValObj = ToObjectValue(value);
-            return _table.PutIfMatch(key, newValObj, ref oldValObj, ValueMatch.NullOrDead);
+            TValue oldVal = default;
+            return _table.PutIfMatch(key, value, ref oldVal, ValueMatch.NullOrDead);
         }
 
         /// <summary>
@@ -436,9 +435,8 @@ namespace NonBlocking
             }
             set
             {
-                object oldValObj = null;
-                object newValObj = ToObjectValue(value);
-                _table.PutIfMatch(key, newValObj, ref oldValObj, ValueMatch.Any);
+                TValue oldVal = default;
+                _table.PutIfMatch(key, value, ref oldVal, ValueMatch.Any);
             }
         }
 
@@ -509,9 +507,8 @@ namespace NonBlocking
         /// reference.</exception>
         public bool TryUpdate(TKey key, TValue newValue, TValue comparisonValue)
         {
-            object oldValObj = ToObjectValue(comparisonValue);
-            object newValObj = ToObjectValue(newValue);
-            return _table.PutIfMatch(key, newValObj, ref oldValObj, ValueMatch.OldValue);
+            TValue oldVal = comparisonValue;
+            return _table.PutIfMatch(key, newValue, ref oldVal, ValueMatch.OldValue);
         }
 
         /// <summary>
@@ -528,14 +525,13 @@ namespace NonBlocking
         /// key is already in the dictionary, or the new value if the key was not in the dictionary.</returns>
         public TValue GetOrAdd(TKey key, TValue value)
         {
-            object oldValObj = null;
-            object newValObj = ToObjectValue(value);
-            if (_table.PutIfMatch(key, newValObj, ref oldValObj, ValueMatch.NullOrDead))
+            TValue oldVal = default;
+            if (_table.PutIfMatch(key, value, ref oldVal, ValueMatch.NullOrDead))
             {
                 return value;
             }
 
-            return FromObjectValue(oldValObj);
+            return FromObjectValue(oldVal);
         }
 
         /// <summary>

--- a/src/NonBlocking/ConcurrentDictionary/DictionaryImpl.cs
+++ b/src/NonBlocking/ConcurrentDictionary/DictionaryImpl.cs
@@ -13,7 +13,7 @@ namespace NonBlocking
 
         internal enum ValueMatch
         {
-            Any,            // sets new value unconditionally, used by index set
+            Any,            // sets new value unconditionally, used by index set and TryRemove(key)
             NullOrDead,     // set value if original value is null or dead, used by Add/TryAdd
             NotNullOrDead,  // set value if original value is alive, used by Remove
             OldValue,       // sets new value if old value matches

--- a/src/NonBlocking/ConcurrentDictionary/DictionaryImpl`2.cs
+++ b/src/NonBlocking/ConcurrentDictionary/DictionaryImpl`2.cs
@@ -35,7 +35,7 @@ namespace NonBlocking
         internal abstract int Count { get; }
 
         internal abstract object TryGetValue(TKey key);
-        internal abstract bool PutIfMatch(TKey key, object newVal, ref object oldValue, ValueMatch match);
+        internal abstract bool PutIfMatch(TKey key, TValue newVal, ref TValue oldValue, ValueMatch match);
         internal abstract bool RemoveIfMatch(TKey key, ref TValue oldValue, ValueMatch match);
         internal abstract TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory);
 

--- a/src/NonBlocking/ConcurrentDictionary/DictionaryImpl`2.cs
+++ b/src/NonBlocking/ConcurrentDictionary/DictionaryImpl`2.cs
@@ -36,6 +36,7 @@ namespace NonBlocking
 
         internal abstract object TryGetValue(TKey key);
         internal abstract bool PutIfMatch(TKey key, object newVal, ref object oldValue, ValueMatch match);
+        internal abstract bool RemoveIfMatch(TKey key, ref TValue oldValue, ValueMatch match);
         internal abstract TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory);
 
         internal abstract IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator();


### PR DESCRIPTION
This change addresses the root cause for regressions described in #6.

Overall performance change will vary depending on scenario. 
It should significantly reduce allocations when `TValue` is a primitive that can be written atomically - `int`, `long`, etc..

Fixes: #6