### PR TITLE
Enable nullability and trimming

### DIFF
--- a/src/NonBlocking/Counter/Counter32.cs
+++ b/src/NonBlocking/Counter/Counter32.cs
@@ -29,7 +29,7 @@ namespace NonBlocking
         }
 
         // spaced out counters
-        private Cell[] cells;
+        private Cell[]? cells;
 
         // default counter
         private int count;
@@ -152,7 +152,7 @@ namespace NonBlocking
         {
             ref var countRef = ref count;
 
-            Cell[] cells;
+            Cell[]? cells;
             if ((cells = this.cells) != null && curCellCount > 1)
             {
                 var cell = cells[GetIndex((uint)curCellCount)];

--- a/src/NonBlocking/Counter/Counter64.cs
+++ b/src/NonBlocking/Counter/Counter64.cs
@@ -29,7 +29,7 @@ namespace NonBlocking
         }
 
         // spaced out counters
-        private Cell[] cells;
+        private Cell[]? cells;
 
         // default counter
         private long count;
@@ -152,7 +152,7 @@ namespace NonBlocking
         {
             ref var countRef = ref count;
 
-            Cell[] cells;
+            Cell[]? cells;
             if ((cells = this.cells) != null && curCellCount > 1)
             {
                 var cell = cells[GetIndex((uint)curCellCount)];

--- a/src/NonBlocking/ILLink.Descriptors.xml
+++ b/src/NonBlocking/ILLink.Descriptors.xml
@@ -1,7 +1,0 @@
-<linker>
-  <assembly fullname="NonBlocking">
-    <type fullname="NonBlocking.DictionaryImpl">
-      <method name="CreateRef" />
-    </type>
-  </assembly>
-</linker>

--- a/src/NonBlocking/ILLink.Descriptors.xml
+++ b/src/NonBlocking/ILLink.Descriptors.xml
@@ -1,0 +1,7 @@
+<linker>
+  <assembly fullname="NonBlocking">
+    <type fullname="NonBlocking.DictionaryImpl">
+      <method name="CreateRef" />
+    </type>
+  </assembly>
+</linker>

--- a/src/NonBlocking/NonBlocking.csproj
+++ b/src/NonBlocking/NonBlocking.csproj
@@ -37,6 +37,13 @@
     <PackageProjectUrl>https://github.com/VSadov/NonBlocking</PackageProjectUrl>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <IsTrimmable>true</IsTrimmable>
+    <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\Release\netstandard2.1\NonBlocking.xml</DocumentationFile>
     <DebugType>pdbonly</DebugType>

--- a/src/NonBlocking/NonBlocking.csproj
+++ b/src/NonBlocking/NonBlocking.csproj
@@ -65,4 +65,8 @@
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.3.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <TrimmerRootDescriptor Include="$(MSBuildThisFileDirectory)ILLink.Descriptors.xml" />
+  </ItemGroup>
+
 </Project>

--- a/src/NonBlocking/NonBlocking.csproj
+++ b/src/NonBlocking/NonBlocking.csproj
@@ -65,8 +65,4 @@
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <TrimmerRootDescriptor Include="$(MSBuildThisFileDirectory)ILLink.Descriptors.xml" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
This is a small change to explicitly enable nullable (in addition to existing attributes) and trimming.

Also, https://github.com/VSadov/NonBlocking/blob/master/src/NonBlocking/ConcurrentDictionary/ConcurrentDictionary.cs#L154 produces an AOT warning so I'm going to look whether it is fixable later on - will submit a PR once (hopefully) fixed.