### PR TITLE
Use IsReferenceOrContainsReferences, when available.

### DIFF
--- a/src/NonBlocking/ConcurrentDictionary/DictionaryImpl`3.cs
+++ b/src/NonBlocking/ConcurrentDictionary/DictionaryImpl`3.cs
@@ -98,7 +98,11 @@ namespace NonBlocking
             this._size = new Counter32();
             this._topDict = topDict;
 
+#if NETSTANDARD2_1_OR_GREATER
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
+#else
             if (!typeof(TKeyStore).IsValueType)
+#endif
             {
                 // do not create a real sweeper just yet. Often it is not needed.
                 topDict._sweeperInstance = NULLVALUE;


### PR DESCRIPTION
If the key does not contain references, we do not need to sweep deleted keys.
This is a more precise condition than when the key is not a primitive value type.