### PR TITLE
Compatibility with Visual Studio 2022

### DIFF
--- a/test/NonBlockingTests/ConcurrentDictionaryTests.cs
+++ b/test/NonBlockingTests/ConcurrentDictionaryTests.cs
@@ -740,7 +740,7 @@ namespace NonBlockingTests
             // "TestConstructor:  FAILED.  Constructor didn't throw ANE when collection has null key passed");
 
             // Duplicate keys.
-            Assert.Throws<ArgumentException>(null, () => new NonBlocking.ConcurrentDictionary<int, int>(new[] { new KeyValuePair<int, int>(1, 1), new KeyValuePair<int, int>(1, 2) }));
+            Assert.Throws<ArgumentException>(() => new NonBlocking.ConcurrentDictionary<int, int>(new[] { new KeyValuePair<int, int>(1, 1), new KeyValuePair<int, int>(1, 2) }));
 
             Assert.Throws<ArgumentNullException>(
                () => new NonBlocking.ConcurrentDictionary<int, int>(1, null, EqualityComparer<int>.Default));
@@ -823,7 +823,7 @@ namespace NonBlockingTests
 
             // Duplicate key.
             dictionary.TryAdd("1", 1);
-            Assert.Throws<ArgumentException>(null, () => ((IDictionary<string, int>)dictionary).Add("1", 2));
+            Assert.Throws<ArgumentException>(() => ((IDictionary<string, int>)dictionary).Add("1", 2));
         }
 
         [Fact]
@@ -887,10 +887,10 @@ namespace NonBlockingTests
             // "TestIDictionary:  FAILED.  Add didn't throw ANE when null key is passed");
 
             // Invalid key type.
-            Assert.Throws<ArgumentException>(null, () => dictionary.Add(1, 1));
+            Assert.Throws<ArgumentException>(() => dictionary.Add(1, 1));
 
             // Invalid value type.
-            Assert.Throws<ArgumentException>(null, () => dictionary.Add("1", "1"));
+            Assert.Throws<ArgumentException>(() => dictionary.Add("1", "1"));
 
             Assert.Throws<ArgumentNullException>(
                () => dictionary.Contains(null));
@@ -910,10 +910,10 @@ namespace NonBlockingTests
             // "TestIDictionary:  FAILED.  this[] setter didn't throw ANE when null key is passed");
 
             // Invalid key type.
-            Assert.Throws<ArgumentException>(null, () => dictionary[1] = 0);
+            Assert.Throws<ArgumentException>(() => dictionary[1] = 0);
 
             // Invalid value type.
-            Assert.Throws<ArgumentException>(null, () => dictionary["1"] = "0");
+            Assert.Throws<ArgumentException>(() => dictionary["1"] = "0");
         }
 
         [Fact]
@@ -966,7 +966,7 @@ namespace NonBlockingTests
 
             //add one item to the dictionary
             ((NonBlocking.ConcurrentDictionary<int, int>)dictionary).TryAdd(1, 1);
-            Assert.Throws<ArgumentException>(null, () => dictionary.CopyTo(new object[] { }, 0));
+            Assert.Throws<ArgumentException>(() => dictionary.CopyTo(new object[] { }, 0));
             // "TestICollection:  FAILED.  CopyTo didn't throw AE when the Array size is smaller than the dictionary count");
         }
 

--- a/test/NonBlockingTests/NonBlockingTests.csproj
+++ b/test/NonBlockingTests/NonBlockingTests.csproj
@@ -1,17 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
-        <ServerGarbageCollection>true</ServerGarbageCollection>
-        <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
-        <RetainVMGarbageCollection>true</RetainVMGarbageCollection>
-        <TieredCompilation>false</TieredCompilation>
-    </PropertyGroup>
-    <ItemGroup>
-      <PackageReference Include="xunit" Version="2.4.1" />
-    </ItemGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+    <RetainVMGarbageCollection>true</RetainVMGarbageCollection>
+    <TieredCompilation>false</TieredCompilation>
+    <StartupObject>NonBlockingTests.Program</StartupObject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\NonBlocking\NonBlocking.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NonBlocking\NonBlocking.csproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Without the runner, VS would not run tests in Test Explorer. It will also get confused about the startup object if it is not set.