### PR TITLE
Do not use the lowermost bit when forcing hash to not match known values

### DIFF
--- a/src/NonBlocking/ConcurrentDictionary/DictionaryImpl`3.cs
+++ b/src/NonBlocking/ConcurrentDictionary/DictionaryImpl`3.cs
@@ -174,8 +174,8 @@ namespace NonBlocking
 
             int h = _keyComparer.GetHashCode(key);
 
-            // ensure that hash never matches 0, TOMBPRIMEHASH, ZEROHASH or REGULAR_HASH_BITS
-            return h | (SPECIAL_HASH_BITS | 1);
+            // ensure that hash never matches TOMBPRIMEHASH, ZEROHASH, SPECIAL_HASH_BITS or 0
+            return h | (SPECIAL_HASH_BITS | (1 << 29));
         }
 
         internal sealed override int Count


### PR DESCRIPTION

We need to make sure that the real hashes do not match one of the special values. That requires wasting of a few bits of the hash, but we have a choice which bits we are sacrificing. 

The lowermost bit might not be the best choice as it is plausible that some hashing schemes will produce consecutive/dense hashes and ` | 1` will result in a collision in every adjacent pair.

Fixes: https://github.com/VSadov/NonBlocking/issues/21