### PR TITLE
Fix invalid Box<TKey> and number dereference in dict. implementations...

### DIFF
--- a/BenchmarksCore/BenchmarksCore.csproj
+++ b/BenchmarksCore/BenchmarksCore.csproj
@@ -2,11 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net7.0</TargetFramework>
     <ServerGarbageCollection>true</ServerGarbageCollection>
-    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
-    <RetainVMGarbageCollection>true</RetainVMGarbageCollection>
-    <TieredCompilation>false</TieredCompilation>
+    <TieredPGO>True</TieredPGO>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NonBlocking/ConcurrentDictionary/DictionaryImpl.SnapshotImpl.cs
+++ b/src/NonBlocking/ConcurrentDictionary/DictionaryImpl.SnapshotImpl.cs
@@ -27,16 +27,11 @@ namespace NonBlocking
                 // linearization point.
                 // if table is quiescent and has no copy in progress,
                 // we can simply iterate over its table.
-                while (true)
+                while (_table._newTable != null)
                 {
-                    if (_table._newTable == null)
-                    {
-                        break;
-                    }
-
                     // there is a copy in progress, finish it and try again
                     _table.HelpCopy(copy_all: true);
-                    this._table = (DictionaryImpl<TKey, TKeyStore, TValue>)(this._table._topDict._table);
+                    this._table = (DictionaryImpl<TKey, TKeyStore, TValue>)this._table._topDict._table;
                 }
             }
 

--- a/src/NonBlocking/ConcurrentDictionary/DictionaryImpl.cs
+++ b/src/NonBlocking/ConcurrentDictionary/DictionaryImpl.cs
@@ -10,8 +10,6 @@ namespace NonBlocking
 {
     internal abstract class DictionaryImpl
     {
-        internal DictionaryImpl() { }
-
         internal enum ValueMatch
         {
             Any,            // sets new value unconditionally, used by index set and TryRemove(key)

--- a/src/NonBlocking/ConcurrentDictionary/DictionaryImplBoxed.cs
+++ b/src/NonBlocking/ConcurrentDictionary/DictionaryImplBoxed.cs
@@ -37,7 +37,7 @@ namespace NonBlocking
                 }
             }
 
-            return _keyComparer.Equals(key, entryKey.Value);
+            return _keyComparer.Equals(key, entryKeyValue.Value);
         }
 
         protected override bool TryClaimSlotForCopy(ref Boxed<TKey> entryKey, Boxed<TKey> key)
@@ -54,7 +54,7 @@ namespace NonBlocking
                 }
             }
 
-            return _keyComparer.Equals(key.Value, entryKey.Value);
+            return _keyComparer.Equals(key.Value, entryKeyValue.Value);
         }
 
         protected override bool keyEqual(TKey key, Boxed<TKey> entryKey)

--- a/src/NonBlocking/ConcurrentDictionary/DictionaryImplInt.cs
+++ b/src/NonBlocking/ConcurrentDictionary/DictionaryImplInt.cs
@@ -44,7 +44,7 @@ namespace NonBlocking
                 }
             }
 
-            return key == entryKeyValue || _keyComparer.Equals(key, entryKey);
+            return key == entryKeyValue || _keyComparer.Equals(key, entryKeyValue);
         }
 
         protected override int hash(int key)

--- a/src/NonBlocking/ConcurrentDictionary/DictionaryImplLong.cs
+++ b/src/NonBlocking/ConcurrentDictionary/DictionaryImplLong.cs
@@ -33,7 +33,7 @@ namespace NonBlocking
         {
             var entryKeyValue = entryKey;
             //zero keys are claimed via hash
-            if (entryKeyValue == 0 & key != 0)
+            if (entryKeyValue == 0 && key != 0)
             {
                 entryKeyValue = Interlocked.CompareExchange(ref entryKey, key, 0);
                 if (entryKeyValue == 0)
@@ -44,7 +44,7 @@ namespace NonBlocking
                 }
             }
 
-            return key == entryKeyValue || _keyComparer.Equals(key, entryKey);
+            return key == entryKeyValue || _keyComparer.Equals(key, entryKeyValue);
         }
 
         protected override int hash(long key)
@@ -100,7 +100,7 @@ namespace NonBlocking
         {
             var entryKeyValue = entryKey;
             //zero keys are claimed via hash
-            if (entryKeyValue == 0 & key != 0)
+            if (entryKeyValue == 0 && key != 0)
             {
                 entryKeyValue = Interlocked.CompareExchange(ref entryKey, key, 0);
                 if (entryKeyValue == 0)

--- a/src/NonBlocking/ConcurrentDictionary/DictionaryImplNint.cs
+++ b/src/NonBlocking/ConcurrentDictionary/DictionaryImplNint.cs
@@ -33,7 +33,7 @@ namespace NonBlocking
         {
             var entryKeyValue = entryKey;
             //zero keys are claimed via hash
-            if (entryKeyValue == 0 & key != 0)
+            if (entryKeyValue == 0 && key != 0)
             {
                 entryKeyValue = Interlocked.CompareExchange(ref entryKey, key, (nint)0);
                 if (entryKeyValue == 0)
@@ -44,7 +44,7 @@ namespace NonBlocking
                 }
             }
 
-            return key == entryKeyValue || _keyComparer.Equals(key, entryKey);
+            return key == entryKeyValue || _keyComparer.Equals(key, entryKeyValue);
         }
 
         protected override int hash(nint key)
@@ -100,7 +100,7 @@ namespace NonBlocking
         {
             var entryKeyValue = entryKey;
             //zero keys are claimed via hash
-            if (entryKeyValue == 0 & key != 0)
+            if (entryKeyValue == 0 && key != 0)
             {
                 entryKeyValue = Interlocked.CompareExchange(ref entryKey, key, (nint)0);
                 if (entryKeyValue == 0)

--- a/src/NonBlocking/ConcurrentDictionary/DictionaryImplRef.cs
+++ b/src/NonBlocking/ConcurrentDictionary/DictionaryImplRef.cs
@@ -50,7 +50,7 @@ namespace NonBlocking
                 }
             }
 
-            return (object)key == entryKeyValue || 
+            return (object)key == entryKeyValue ||
                 _keyComparer.Equals(key, Unsafe.As<object, TKey>(ref entryKeyValue));
         }
 

--- a/src/NonBlocking/ConcurrentDictionary/DictionaryImpl`2.cs
+++ b/src/NonBlocking/ConcurrentDictionary/DictionaryImpl`2.cs
@@ -14,10 +14,7 @@ namespace NonBlocking
     internal abstract class DictionaryImpl<TKey, TValue>
         : DictionaryImpl
     {
-        internal readonly bool valueIsValueType = typeof(TValue).IsValueType;
         internal IEqualityComparer<TKey> _keyComparer;
-
-        internal DictionaryImpl() { }
 
         internal abstract void Clear();
         internal abstract int Count { get; }
@@ -72,7 +69,7 @@ namespace NonBlocking
             }
 
             // ref type
-            if (!valueIsValueType)
+            if (!typeof(TValue).IsValueType)
             {
                 return Unsafe.As<object, TValue>(ref obj);
             }

--- a/src/NonBlocking/ConcurrentDictionary/DictionaryImpl`2.cs
+++ b/src/NonBlocking/ConcurrentDictionary/DictionaryImpl`2.cs
@@ -14,6 +14,10 @@ namespace NonBlocking
     internal abstract class DictionaryImpl<TKey, TValue>
         : DictionaryImpl
     {
+#if NETSTANDARD2_0
+        private readonly bool _valueIsValueType = typeof(TValue).IsValueType;
+#endif
+
         internal IEqualityComparer<TKey> _keyComparer;
 
         internal abstract void Clear();
@@ -69,7 +73,11 @@ namespace NonBlocking
             }
 
             // ref type
+#if NETSTANDARD2_0
+            if (!_valueIsValueType)
+#else
             if (!typeof(TValue).IsValueType)
+#endif
             {
                 return Unsafe.As<object, TValue>(ref obj);
             }

--- a/src/NonBlocking/ConcurrentDictionary/DictionaryImpl`3.cs
+++ b/src/NonBlocking/ConcurrentDictionary/DictionaryImpl`3.cs
@@ -70,7 +70,7 @@ namespace NonBlocking
 
         // targeted time span between resizes.
         // if resizing more often than this, try expanding.
-        private const uint RESIZE_MILLIS_TARGET = (uint)1000;
+        private const uint RESIZE_MILLIS_TARGET = 1000;
 
         // create an empty dictionary
         protected abstract DictionaryImpl<TKey, TKeyStore, TValue> CreateNew(int capacity);
@@ -170,12 +170,12 @@ namespace NonBlocking
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected virtual int hash(TKey key)
         {
-            Debug.Assert(!(key is null));
+            Debug.Assert(key is not null);
 
             int h = _keyComparer.GetHashCode(key);
 
             // ensure that hash never matches TOMBPRIMEHASH, ZEROHASH, SPECIAL_HASH_BITS or 0
-            return h | (SPECIAL_HASH_BITS | (1 << 29));
+            return h | SPECIAL_HASH_BITS | (1 << 29);
         }
 
         internal sealed override int Count
@@ -369,7 +369,7 @@ namespace NonBlocking
             // We are finally prepared to update the existing table
             while (true)
             {
-                Debug.Assert(!(entryValue is Prime));
+                Debug.Assert(entryValue is not Prime);
 
                 // can't remove if nothing is there
                 if (EntryValueNullOrDead(entryValue))
@@ -745,10 +745,10 @@ namespace NonBlocking
 
             // prev value is null or dead.
             // let's try install new value
-            newValObj = newValObj ?? ToObjectValue(result = valueFactory(key));
+            newValObj ??= ToObjectValue(result = valueFactory(key));
             while (true)
             {
-                Debug.Assert(!(entryValue is Prime));
+                Debug.Assert(entryValue is not Prime);
 
                 // Actually change the Value
                 var prev = Interlocked.CompareExchange(ref entry.value, newValObj, entryValue);

--- a/src/NonBlocking/ConcurrentDictionary/DictionaryImpl`3.cs
+++ b/src/NonBlocking/ConcurrentDictionary/DictionaryImpl`3.cs
@@ -175,7 +175,7 @@ namespace NonBlocking
             int h = _keyComparer.GetHashCode(key);
 
             // ensure that hash never matches TOMBPRIMEHASH, ZEROHASH, SPECIAL_HASH_BITS or 0
-            return h | SPECIAL_HASH_BITS | (1 << 29);
+            return h | (SPECIAL_HASH_BITS | (1 << 29));
         }
 
         internal sealed override int Count

--- a/src/NonBlocking/Counter/Counter32.cs
+++ b/src/NonBlocking/Counter/Counter32.cs
@@ -38,14 +38,6 @@ namespace NonBlocking
         private int lastCount;
 
         /// <summary>
-        /// Initializes a new instance of the <see
-        /// cref="Counter32"/>
-        /// </summary>
-        public Counter32()
-        {
-        }
-
-        /// <summary>
         /// Returns the value of the counter at the time of the call.
         /// </summary>
         /// <remarks>

--- a/src/NonBlocking/Counter/Counter64.cs
+++ b/src/NonBlocking/Counter/Counter64.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace NonBlocking
-{    
+{
     /// <summary>
     /// Scalable 64bit counter that can be used from multiple threads.
     /// </summary>
@@ -36,14 +36,6 @@ namespace NonBlocking
 
         // delayed count
         private long lastCount;
-
-        /// <summary>
-        /// Initializes a new instance of the <see
-        /// cref="Counter32"/>
-        /// </summary>
-        public Counter64()
-        {
-        }
 
         /// <summary>
         /// Returns the value of the counter at the time of the call.

--- a/src/NonBlocking/NonBlocking.csproj
+++ b/src/NonBlocking/NonBlocking.csproj
@@ -39,7 +39,6 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
-    <IsTrimmable>true</IsTrimmable>
     <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
   </PropertyGroup>
 

--- a/test/NonBlockingTests/NonBlockingTests.csproj
+++ b/test/NonBlockingTests/NonBlockingTests.csproj
@@ -1,11 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <ServerGarbageCollection>true</ServerGarbageCollection>
-    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
-    <RetainVMGarbageCollection>true</RetainVMGarbageCollection>
-    <TieredCompilation>false</TieredCompilation>
+    <TieredPGO>True</TieredPGO>
     <StartupObject>NonBlockingTests.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>

--- a/test/NonBlockingTests/Program.cs
+++ b/test/NonBlockingTests/Program.cs
@@ -17,8 +17,11 @@ namespace NonBlockingTests
 {
     public class Program
     {
-        private static readonly bool s_isStrong = 
-            RuntimeInformation.ProcessArchitecture == Architecture.X64 || 
+        private static ReadOnlySpan<int> ConcurrentIterations =>
+            new int[] { 10, 100, 1000, 10000, 100000, 1000000 };
+
+        private static readonly bool s_isStrong =
+            RuntimeInformation.ProcessArchitecture == Architecture.X64 ||
             RuntimeInformation.ProcessArchitecture == Architecture.X86;
 
         static void Main(string[] args)
@@ -33,7 +36,6 @@ namespace NonBlockingTests
                 AddSetRemoveConcurrent();
                 System.Console.WriteLine("AddSetRemoveConcurrentInt");
                 AddSetRemoveConcurrentInt();
-                AddSetRemoveConcurrent();
 
                 System.Console.WriteLine("AddSetRemoveConcurrentIntInt");
                 AddSetRemoveConcurrentIntInt();
@@ -48,6 +50,9 @@ namespace NonBlockingTests
 
                 System.Console.WriteLine("AddSetRemoveConcurrentStruct");
                 AddSetRemoveConcurrentStruct();
+
+                System.Console.WriteLine("AddSetRemoveConcurrentNullIntolerant");
+                AddSetRemoveConcurrentNullIntolerant();
 
                 System.Console.WriteLine("NullValueRef");
                 NullValueRef();
@@ -237,28 +242,13 @@ namespace NonBlockingTests
         {
             var dict = new NonBlocking.ConcurrentDictionary<object, string>();
 
-            Parallel.For(0, 10, (i) => dict.TryAdd(i, i.ToString()));
-            Parallel.For(0, 10, (i) => dict[i] = i.ToString());
-            Parallel.For(0, 10, (i) => { if (dict[i] != i.ToString()) throw new Exception(); });
-            Parallel.For(0, 10, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 100, (i) => dict[i] = i.ToString());
-            Parallel.For(0, 100, (i) => { if (dict[i] != i.ToString()) throw new Exception(); });
-            Parallel.For(0, 100, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 1000, (i) => dict.TryAdd(i, i.ToString()));
-            Parallel.For(0, 1000, (i) => dict[i] = i.ToString());
-            Parallel.For(0, 1000, (i) => { if (dict[i] != i.ToString()) throw new Exception(); });
-            Parallel.For(0, 1000, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
-            Parallel.For(0, 1000, (i) => { if (dict.TryRemove(i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 10000, (i) => dict.TryAdd(i, i.ToString()));
-            Parallel.For(0, 10000, (i) => { if (dict[i] != i.ToString()) throw new Exception(); });
-            Parallel.For(0, 10000, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 100000, (i) => dict[i] = i.ToString());
-            Parallel.For(0, 100000, (i) => { if (dict[i] != i.ToString()) throw new Exception(); });
-            Parallel.For(0, 100000, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
+            foreach (var iterations in ConcurrentIterations)
+            {
+                Parallel.For(0, iterations, (i) => dict.TryAdd(i, i.ToString()));
+                Parallel.For(0, iterations, (i) => dict[i] = i.ToString());
+                Parallel.For(0, iterations, (i) => { if (dict[i] != i.ToString()) throw new Exception(); });
+                Parallel.For(0, iterations, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
+            }
         }
 
         class NullIntolerantComparer : IEqualityComparer<object>
@@ -282,31 +272,16 @@ namespace NonBlockingTests
         {
             var dict = new NonBlocking.ConcurrentDictionary<object, int>(new NullIntolerantComparer());
 
-            var keys = new object[100000];
+            var keys = new object[ConcurrentIterations[^1]];
             for (int i = 0; i < keys.Length; i++) keys[i] = i;
 
-            Parallel.For(0, 10, (i) => dict.TryAdd(keys[i], i));
-            Parallel.For(0, 10, (i) => dict[keys[i]] = i);
-            Parallel.For(0, 10, (i) => { if (dict[keys[i]] != i) throw new Exception(); });
-            Parallel.For(0, 10, (i) => { if (!dict.TryRemove(keys[i], out var _)) throw new Exception(); });
-
-            Parallel.For(0, 100, (i) => dict[keys[i]] = i);
-            Parallel.For(0, 100, (i) => { if (dict[keys[i]] != i) throw new Exception(); });
-            Parallel.For(0, 100, (i) => { if (!dict.TryRemove(keys[i], out var _)) throw new Exception(); });
-
-            Parallel.For(0, 1000, (i) => dict.TryAdd(keys[i], i));
-            Parallel.For(0, 1000, (i) => dict[keys[i]] = i);
-            Parallel.For(0, 1000, (i) => { if (dict[keys[i]] != i) throw new Exception(); });
-            Parallel.For(0, 1000, (i) => { if (!dict.TryRemove(keys[i], out var _)) throw new Exception(); });
-            Parallel.For(0, 1000, (i) => { if (dict.TryRemove(keys[i], out var _)) throw new Exception(); });
-
-            Parallel.For(0, 10000, (i) => dict.TryAdd(keys[i], i));
-            Parallel.For(0, 10000, (i) => { if (dict[keys[i]] != i) throw new Exception(); });
-            Parallel.For(0, 10000, (i) => { if (!dict.TryRemove(keys[i], out var _)) throw new Exception(); });
-
-            Parallel.For(0, 100000, (i) => dict[keys[i]] = i);
-            Parallel.For(0, 100000, (i) => { if (dict[keys[i]] != i) throw new Exception(); });
-            Parallel.For(0, 100000, (i) => { if (!dict.TryRemove(keys[i], out var _)) throw new Exception(); });
+            foreach (var iterations in ConcurrentIterations)
+            {
+                Parallel.For(0, iterations, (i) => dict.TryAdd(keys[i], i));
+                Parallel.For(0, iterations, (i) => dict[keys[i]] = i);
+                Parallel.For(0, iterations, (i) => { if (dict[keys[i]] != i) throw new Exception(); });
+                Parallel.For(0, iterations, (i) => { if (!dict.TryRemove(keys[i], out var _)) throw new Exception(); });
+            }
         }
 
         [Fact()]
@@ -314,28 +289,13 @@ namespace NonBlockingTests
         {
             var dict = new NonBlocking.ConcurrentDictionary<int, string>();
 
-            Parallel.For(0, 10, (i) => dict.TryAdd(i, i.ToString()));
-            Parallel.For(0, 10, (i) => dict[i] = i.ToString());
-            Parallel.For(0, 10, (i) => { if (dict[i] != i.ToString()) throw new Exception(); });
-            Parallel.For(0, 10, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 100, (i) => dict[i] = i.ToString());
-            Parallel.For(0, 100, (i) => { if (dict[i] != i.ToString()) throw new Exception(); });
-            Parallel.For(0, 100, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 1000, (i) => dict.TryAdd(i, i.ToString()));
-            Parallel.For(0, 1000, (i) => dict[i] = i.ToString());
-            Parallel.For(0, 1000, (i) => { if (dict[i] != i.ToString()) throw new Exception(); });
-            Parallel.For(0, 1000, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
-            Parallel.For(0, 1000, (i) => { if (dict.TryRemove(i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 10000, (i) => dict.TryAdd(i, i.ToString()));
-            Parallel.For(0, 10000, (i) => { if (dict[i] != i.ToString()) throw new Exception(); });
-            Parallel.For(0, 10000, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 100000, (i) => dict[i] = i.ToString());
-            Parallel.For(0, 100000, (i) => { if (dict[i] != i.ToString()) throw new Exception(); });
-            Parallel.For(0, 100000, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
+            foreach (var iterations in ConcurrentIterations)
+            {
+                Parallel.For(0, iterations, (i) => dict.TryAdd(i, i.ToString()));
+                Parallel.For(0, iterations, (i) => dict[i] = i.ToString());
+                Parallel.For(0, iterations, (i) => { if (dict[i] != i.ToString()) throw new Exception(); });
+                Parallel.For(0, iterations, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
+            }
         }
 
         [Fact()]
@@ -343,28 +303,14 @@ namespace NonBlockingTests
         {
             var dict = new NonBlocking.ConcurrentDictionary<int, int>();
 
-            Parallel.For(0, 10, (i) => dict.TryAdd(i, i));
-            Parallel.For(0, 10, (i) => dict[i] = i);
-            Parallel.For(0, 10, (i) => { if (dict[i] != i) throw new Exception(); });
-            Parallel.For(0, 10, (i) => { int ii; if (!dict.TryRemove(i, out ii)) throw new Exception(); });
-
-            Parallel.For(0, 100, (i) => dict[i] = i);
-            Parallel.For(0, 100, (i) => { if (dict[i] != i) throw new Exception(); });
-            Parallel.For(0, 100, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 1000, (i) => dict.TryAdd(i, i));
-            Parallel.For(0, 1000, (i) => dict[i] = i);
-            Parallel.For(0, 1000, (i) => { if (dict[i] != i) throw new Exception(); });
-            Parallel.For(0, 1000, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
-            Parallel.For(0, 1000, (i) => { if (dict.TryRemove(i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 10000, (i) => dict.TryAdd(i, i));
-            Parallel.For(0, 10000, (i) => { if (dict[i] != i) throw new Exception(); });
-            Parallel.For(0, 10000, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 100000, (i) => dict[i] = i);
-            Parallel.For(0, 100000, (i) => { if (dict[i] != i) throw new Exception(); });
-            Parallel.For(0, 100000, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
+            foreach (var iterations in ConcurrentIterations)
+            {
+                Parallel.For(0, iterations, (i) => dict.TryAdd(i, i));
+                Parallel.For(0, iterations, (i) => dict[i] = i);
+                Parallel.For(0, iterations, (i) => { if (dict[i] != i) throw new Exception(); });
+                Parallel.For(0, iterations, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
+                Parallel.For(0, iterations, (i) => { if (dict.TryRemove(i, out var _)) throw new Exception(); });
+            }
         }
 
         [Fact()]
@@ -372,28 +318,14 @@ namespace NonBlockingTests
         {
             var dict = new NonBlocking.ConcurrentDictionary<uint, int>();
 
-            Parallel.For(0, 10, (i) => dict.TryAdd((uint)i, i));
-            Parallel.For(0, 10, (i) => dict[(uint)i] = i);
-            Parallel.For(0, 10, (i) => { if (dict[(uint)i] != i) throw new Exception(); });
-            Parallel.For(0, 10, (i) => { int ii; if (!dict.TryRemove((uint)i, out ii)) throw new Exception(); });
-
-            Parallel.For(0, 100, (i) => dict[(uint)i] = i);
-            Parallel.For(0, 100, (i) => { if (dict[(uint)i] != i) throw new Exception(); });
-            Parallel.For(0, 100, (i) => { if (!dict.TryRemove((uint)i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 1000, (i) => dict.TryAdd((uint)i, i));
-            Parallel.For(0, 1000, (i) => dict[(uint)i] = i);
-            Parallel.For(0, 1000, (i) => { if (dict[(uint)i] != i) throw new Exception(); });
-            Parallel.For(0, 1000, (i) => { if (!dict.TryRemove((uint)i, out var _)) throw new Exception(); });
-            Parallel.For(0, 1000, (i) => { if (dict.TryRemove((uint)i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 10000, (i) => dict.TryAdd((uint)i, i));
-            Parallel.For(0, 10000, (i) => { if (dict[(uint)i] != i) throw new Exception(); });
-            Parallel.For(0, 10000, (i) => { if (!dict.TryRemove((uint)i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 100000, (i) => dict[(uint)i] = i);
-            Parallel.For(0, 100000, (i) => { if (dict[(uint)i] != i) throw new Exception(); });
-            Parallel.For(0, 100000, (i) => { if (!dict.TryRemove((uint)i, out var _)) throw new Exception(); });
+            foreach (var iterations in ConcurrentIterations)
+            {
+                Parallel.For(0, iterations, (i) => dict.TryAdd((uint)i, i));
+                Parallel.For(0, iterations, (i) => dict[(uint)i] = i);
+                Parallel.For(0, iterations, (i) => { if (dict[(uint)i] != i) throw new Exception(); });
+                Parallel.For(0, iterations, (i) => { if (!dict.TryRemove((uint)i, out var _)) throw new Exception(); });
+                Parallel.For(0, iterations, (i) => { if (dict.TryRemove((uint)i, out var _)) throw new Exception(); });
+            }
         }
 
         [Fact()]
@@ -401,24 +333,14 @@ namespace NonBlockingTests
         {
             var dict = new NonBlocking.ConcurrentDictionary<long, long>();
 
-            Parallel.For(0, 10, (i) => dict.TryAdd((long)i, i));
-            Parallel.For(0, 10, (i) => dict[(long)i] = i);
-            Parallel.For(0, 10, (i) => { if (dict[(long)i] != i) throw new Exception(); });
-            Parallel.For(0, 10, (i) => { long ii; if (!dict.TryRemove((long)i, out ii)) throw new Exception(); });
-
-            Parallel.For(0, 100, (i) => dict[(long)i] = i);
-            Parallel.For(0, 100, (i) => { if (dict[(long)i] != i) throw new Exception(); });
-            Parallel.For(0, 100, (i) => { if (!dict.TryRemove((long)i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 1000, (i) => dict.TryAdd((long)i, i));
-            Parallel.For(0, 1000, (i) => dict[(long)i] = i);
-            Parallel.For(0, 1000, (i) => { if (dict[(long)i] != i) throw new Exception(); });
-            Parallel.For(0, 1000, (i) => { if (!dict.TryRemove((long)i, out var _)) throw new Exception(); });
-            Parallel.For(0, 1000, (i) => { if (dict.TryRemove((long)i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 10000, (i) => dict.TryAdd((long)i, i));
-            Parallel.For(0, 10000, (i) => { if (dict[(long)i] != i) throw new Exception(); });
-            Parallel.For(0, 10000, (i) => { if (!dict.TryRemove((long)i, out var _)) throw new Exception(); });
+            foreach (var iterations in ConcurrentIterations)
+            {
+                Parallel.For(0, iterations, (i) => dict.TryAdd((long)i, i));
+                Parallel.For(0, iterations, (i) => dict[(long)i] = i);
+                Parallel.For(0, iterations, (i) => { if (dict[(long)i] != i) throw new Exception(); });
+                Parallel.For(0, iterations, (i) => { if (!dict.TryRemove((long)i, out var _)) throw new Exception(); });
+                Parallel.For(0, iterations, (i) => { if (dict.TryRemove((long)i, out var _)) throw new Exception(); });
+            }
 
             Parallel.For((long)int.MaxValue + 1L, (long)int.MaxValue + 100000, (i) => dict[(long)i] = i);
             Parallel.For((long)int.MaxValue + 1L, (long)int.MaxValue + 100000, (i) => { if (dict[(long)i] != i) throw new Exception(); });
@@ -430,24 +352,14 @@ namespace NonBlockingTests
         {
             var dict = new NonBlocking.ConcurrentDictionary<ulong, long>();
 
-            Parallel.For(0, 10, (i) => dict.TryAdd((ulong)i, i));
-            Parallel.For(0, 10, (i) => dict[(ulong)i] = i);
-            Parallel.For(0, 10, (i) => { if (dict[(ulong)i] != i) throw new Exception(); });
-            Parallel.For(0, 10, (i) => { long ii; if (!dict.TryRemove((ulong)i, out ii)) throw new Exception(); });
-
-            Parallel.For(0, 100, (i) => dict[(ulong)i] = i);
-            Parallel.For(0, 100, (i) => { if (dict[(ulong)i] != i) throw new Exception(); });
-            Parallel.For(0, 100, (i) => { if (!dict.TryRemove((ulong)i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 1000, (i) => dict.TryAdd((ulong)i, i));
-            Parallel.For(0, 1000, (i) => dict[(ulong)i] = i);
-            Parallel.For(0, 1000, (i) => { if (dict[(ulong)i] != i) throw new Exception(); });
-            Parallel.For(0, 1000, (i) => { if (!dict.TryRemove((ulong)i, out var _)) throw new Exception(); });
-            Parallel.For(0, 1000, (i) => { if (dict.TryRemove((ulong)i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 10000, (i) => dict.TryAdd((ulong)i, i));
-            Parallel.For(0, 10000, (i) => { if (dict[(ulong)i] != i) throw new Exception(); });
-            Parallel.For(0, 10000, (i) => { if (!dict.TryRemove((ulong)i, out var _)) throw new Exception(); });
+            foreach (var iterations in ConcurrentIterations)
+            {
+                Parallel.For(0, iterations, (i) => dict.TryAdd((ulong)i, i));
+                Parallel.For(0, iterations, (i) => dict[(ulong)i] = i);
+                Parallel.For(0, iterations, (i) => { if (dict[(ulong)i] != i) throw new Exception(); });
+                Parallel.For(0, iterations, (i) => { if (!dict.TryRemove((ulong)i, out var _)) throw new Exception(); });
+                Parallel.For(0, iterations, (i) => { if (dict.TryRemove((ulong)i, out var _)) throw new Exception(); });
+            }
 
             Parallel.For((long)int.MaxValue + 1L, (long)int.MaxValue + 100000, (i) => dict[(ulong)i] = i);
             Parallel.For((long)int.MaxValue + 1L, (long)int.MaxValue + 100000, (i) => { if (dict[(ulong)i] != i) throw new Exception(); });
@@ -461,28 +373,14 @@ namespace NonBlockingTests
             {
                 var dict = new NonBlocking.ConcurrentDictionary<nint, long>();
 
-                Parallel.For(0, 10, (i) => dict.TryAdd((nint)i, i));
-                Parallel.For(0, 10, (i) => dict[(nint)i] = i);
-                Parallel.For(0, 10, (i) => { if (dict[(nint)i] != i) throw new Exception(); });
-                Parallel.For(0, 10, (i) => { long ii; if (!dict.TryRemove((nint)i, out ii)) throw new Exception(); });
-
-                Parallel.For(0, 100, (i) => dict[(nint)i] = i);
-                Parallel.For(0, 100, (i) => { if (dict[(nint)i] != i) throw new Exception(); });
-                Parallel.For(0, 100, (i) => { if (!dict.TryRemove((nint)i, out var _)) throw new Exception(); });
-
-                Parallel.For(0, 1000, (i) => dict.TryAdd((nint)i, i));
-                Parallel.For(0, 1000, (i) => dict[(nint)i] = i);
-                Parallel.For(0, 1000, (i) => { if (dict[(nint)i] != i) throw new Exception(); });
-                Parallel.For(0, 1000, (i) => { if (!dict.TryRemove((nint)i, out var _)) throw new Exception(); });
-                Parallel.For(0, 1000, (i) => { if (dict.TryRemove((nint)i, out var _)) throw new Exception(); });
-
-                Parallel.For(0, 10000, (i) => dict.TryAdd((nint)i, i));
-                Parallel.For(0, 10000, (i) => { if (dict[(nint)i] != i) throw new Exception(); });
-                Parallel.For(0, 10000, (i) => { if (!dict.TryRemove((nint)i, out var _)) throw new Exception(); });
-
-                Parallel.For(0, 100000, (i) => dict[(nint)i] = i);
-                Parallel.For(0, 100000, (i) => { if (dict[(nint)i] != i) throw new Exception(); });
-                Parallel.For(0, 100000, (i) => { if (!dict.TryRemove((nint)i, out var _)) throw new Exception(); });
+                foreach (var iterations in ConcurrentIterations)
+                {
+                    Parallel.For(0, iterations, (i) => dict.TryAdd((nint)i, i));
+                    Parallel.For(0, iterations, (i) => dict[(nint)i] = i);
+                    Parallel.For(0, iterations, (i) => { if (dict[(nint)i] != i) throw new Exception(); });
+                    Parallel.For(0, iterations, (i) => { if (!dict.TryRemove((nint)i, out var _)) throw new Exception(); });
+                    Parallel.For(0, iterations, (i) => { if (dict.TryRemove((nint)i, out var _)) throw new Exception(); });
+                }
 
                 Parallel.For((long)int.MaxValue + 1L, (long)int.MaxValue + 100000, (i) => dict[(nint)i] = i);
                 Parallel.For((long)int.MaxValue + 1L, (long)int.MaxValue + 100000, (i) => { if (dict[(nint)i] != i) throw new Exception(); });
@@ -490,61 +388,24 @@ namespace NonBlockingTests
             }
         }
 
-        struct S1
+        readonly record struct S1(int I, int J)
         {
-            private int i;
-
-            public static implicit operator S1(int x)
-            {
-                return new S1() { i = x };
-            }
-
-            public override string ToString()
-            {
-                return i.ToString();
-            }
-
-            public class Comparer : IEqualityComparer<S1>
-            {
-                bool IEqualityComparer<S1>.Equals(S1 x, S1 y)
-                {
-                    return x.i == y.i;
-                }
-
-                int IEqualityComparer<S1>.GetHashCode(S1 obj)
-                {
-                    return obj.i;
-                }
-            }
+            public static implicit operator S1(int i) => new(i, -i);
         }
 
         [Fact()]
         private static void AddSetRemoveConcurrentStruct()
         {
-            var dict = new NonBlocking.ConcurrentDictionary<S1, string>(new S1.Comparer());
+            var dict = new NonBlocking.ConcurrentDictionary<S1, string>();
 
-            Parallel.For(0, 10, (i) => dict.TryAdd(i, i.ToString()));
-            Parallel.For(0, 10, (i) => dict[i] = i.ToString());
-            Parallel.For(0, 10, (i) => { if (dict[i] != i.ToString()) throw new Exception(); });
-            Parallel.For(0, 10, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 100, (i) => dict[i] = i.ToString());
-            Parallel.For(0, 100, (i) => { if (dict[i] != i.ToString()) throw new Exception(); });
-            Parallel.For(0, 100, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 1000, (i) => dict.TryAdd(i, i.ToString()));
-            Parallel.For(0, 1000, (i) => dict[i] = i.ToString());
-            Parallel.For(0, 1000, (i) => { if (dict[i] != i.ToString()) throw new Exception(); });
-            Parallel.For(0, 1000, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
-            Parallel.For(0, 1000, (i) => { if (dict.TryRemove(i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 10000, (i) => dict.TryAdd(i, i.ToString()));
-            Parallel.For(0, 10000, (i) => { if (dict[i] != i.ToString()) throw new Exception(); });
-            Parallel.For(0, 10000, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
-
-            Parallel.For(0, 100000, (i) => dict[i] = i.ToString());
-            Parallel.For(0, 100000, (i) => { if (dict[i] != i.ToString()) throw new Exception(); });
-            Parallel.For(0, 100000, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
+            foreach (var iterations in ConcurrentIterations)
+            {
+                Parallel.For(0, iterations, (i) => dict.TryAdd(i, i.ToString()));
+                Parallel.For(0, iterations, (i) => dict[i] = i.ToString());
+                Parallel.For(0, iterations, (i) => { if (dict[i] != i.ToString()) throw new Exception(); });
+                Parallel.For(0, iterations, (i) => { if (!dict.TryRemove(i, out var _)) throw new Exception(); });
+                Parallel.For(0, iterations, (i) => { if (dict.TryRemove(i, out var _)) throw new Exception(); });
+            }
         }
 
         [Fact()]
@@ -604,7 +465,7 @@ namespace NonBlockingTests
         {
             var dict = new NonBlocking.ConcurrentDictionary<object, int>();
 
-            Parallel.ForEach(Enumerable.Range(0, 10000),
+            Parallel.For(0, 10000,
                 (i) =>
                 {
                     dict[i] = 0;
@@ -625,7 +486,7 @@ namespace NonBlockingTests
                     }
                 });
 
-            Parallel.ForEach(Enumerable.Range(0, 10000),
+            Parallel.For(0, 10000,
                     (i) =>
                     {
                         if (i % 2 == 0)
@@ -656,7 +517,7 @@ namespace NonBlockingTests
         {
             var dict = new NonBlocking.ConcurrentDictionary<int, int>();
 
-            Parallel.ForEach(Enumerable.Range(0, 10000),
+            Parallel.For(0, 10000,
                 (i) =>
                 {
                     int val;
@@ -688,7 +549,7 @@ namespace NonBlockingTests
                     }
                 });
 
-            Parallel.ForEach(Enumerable.Range(0, 10000),
+            Parallel.For(0, 10000,
                     (i) =>
                     {
                         int val;
@@ -729,7 +590,7 @@ namespace NonBlockingTests
         {
             var dict = new NonBlocking.ConcurrentDictionary<object, int>();
 
-            Parallel.ForEach(Enumerable.Range(0, 10000),
+            Parallel.For(0, 10000,
                 (i) =>
                 {
                     int val;
@@ -760,7 +621,7 @@ namespace NonBlockingTests
                     }
                 });
 
-            Parallel.ForEach(Enumerable.Range(0, 10000),
+            Parallel.For(0, 10000,
                     (i) =>
                     {
                         int val;
@@ -926,7 +787,7 @@ namespace NonBlockingTests
         {
             var dict = new NonBlocking.ConcurrentDictionary<int, int>();
 
-            Parallel.ForEach(Enumerable.Range(0, 10001),
+            Parallel.For(0, 10001,
                 (i) =>
                 {
                     if (i % 2 == 0)
@@ -977,7 +838,7 @@ namespace NonBlockingTests
         {
             var dict = new NonBlocking.ConcurrentDictionary<object, int>();
 
-            Parallel.ForEach(Enumerable.Range(0, 10001),
+            Parallel.For(0, 10001,
                 (i) =>
                 {
                     if (i % 2 == 0)
@@ -1026,9 +887,9 @@ namespace NonBlockingTests
         [Fact()]
         private static void Relativity003()
         {
-            var dict = new NonBlocking.ConcurrentDictionary<S1, int>(new S1.Comparer());
+            var dict = new NonBlocking.ConcurrentDictionary<S1, int>();
 
-            Parallel.ForEach(Enumerable.Range(0, 10001),
+            Parallel.For(0, 10001,
                 (i) =>
                 {
                     if (i % 2 == 0)
@@ -1082,7 +943,7 @@ namespace NonBlockingTests
             var keys = new string[30000];
             for (int i = 0; i < keys.Length; i++) keys[i] = i.ToString();
 
-            Parallel.ForEach(Enumerable.Range(0, 10001),
+            Parallel.For(0, 10001,
                 (i) =>
                 {
                     if (i % 2 == 0)

--- a/test/NonBlockingTests/Program.cs
+++ b/test/NonBlockingTests/Program.cs
@@ -4,14 +4,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Diagnostics;
-using NonBlocking;
-using System.Collections.Concurrent;
-using Xunit;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Xunit;
 
 namespace NonBlockingTests
 {
@@ -452,7 +449,7 @@ namespace NonBlockingTests
                         }
                     });
 
-            Parallel.For(0, 1000,
+            Parallel.ForEach(Enumerable.Range(0, 1000),
                 (i) =>
                 {
                     if (i % 2 == 0 && dict[i] != 20000) throw new Exception();
@@ -465,7 +462,7 @@ namespace NonBlockingTests
         {
             var dict = new NonBlocking.ConcurrentDictionary<object, int>();
 
-            Parallel.For(0, 10000,
+            Parallel.ForEach(Enumerable.Range(0, 10000),
                 (i) =>
                 {
                     dict[i] = 0;
@@ -486,7 +483,7 @@ namespace NonBlockingTests
                     }
                 });
 
-            Parallel.For(0, 10000,
+            Parallel.ForEach(Enumerable.Range(0, 10000),
                     (i) =>
                     {
                         if (i % 2 == 0)
@@ -504,7 +501,7 @@ namespace NonBlockingTests
                         }
                     });
 
-            Parallel.For(0, 1000,
+            Parallel.ForEach(Enumerable.Range(0, 1000),
                 (i) =>
                 {
                     if (i % 2 == 0 && dict[i] != 20000) throw new Exception();
@@ -517,7 +514,7 @@ namespace NonBlockingTests
         {
             var dict = new NonBlocking.ConcurrentDictionary<int, int>();
 
-            Parallel.For(0, 10000,
+            Parallel.ForEach(Enumerable.Range(0, 10000),
                 (i) =>
                 {
                     int val;
@@ -549,7 +546,7 @@ namespace NonBlockingTests
                     }
                 });
 
-            Parallel.For(0, 10000,
+            Parallel.ForEach(Enumerable.Range(0, 10000),
                     (i) =>
                     {
                         int val;
@@ -577,7 +574,7 @@ namespace NonBlockingTests
                         }
                     });
 
-            Parallel.For(0, 1000,
+            Parallel.ForEach(Enumerable.Range(0, 1000),
                     (i) =>
                     {
                         int val;
@@ -590,7 +587,7 @@ namespace NonBlockingTests
         {
             var dict = new NonBlocking.ConcurrentDictionary<object, int>();
 
-            Parallel.For(0, 10000,
+            Parallel.ForEach(Enumerable.Range(0, 10000),
                 (i) =>
                 {
                     int val;
@@ -621,7 +618,7 @@ namespace NonBlockingTests
                     }
                 });
 
-            Parallel.For(0, 10000,
+            Parallel.ForEach(Enumerable.Range(0, 10000),
                     (i) =>
                     {
                         int val;
@@ -649,7 +646,7 @@ namespace NonBlockingTests
                         }
                     });
 
-            Parallel.For(0, 1000,
+            Parallel.ForEach(Enumerable.Range(0, 1000),
                     (i) =>
                     {
                         int val;
@@ -664,14 +661,14 @@ namespace NonBlockingTests
             var updatedBeforeRemove = new NonBlocking.ConcurrentDictionary<int, bool>();
             var removedValue = new NonBlocking.ConcurrentDictionary<int, int>();
 
-            Parallel.For(0, 10000,
+            Parallel.ForEach(Enumerable.Range(0, 10000),
                 new ParallelOptions(),
                     (i) =>
                     {
                         dict1[i] = 42;
                     });
 
-            Parallel.For(0, 20000,
+            Parallel.ForEach(Enumerable.Range(0, 20000),
                     (i) =>
                     {
                         if (i < 10000)
@@ -704,14 +701,14 @@ namespace NonBlockingTests
             var updatedBeforeRemove = new NonBlocking.ConcurrentDictionary<int, bool>();
             var removedValue = new NonBlocking.ConcurrentDictionary<int, int>();
 
-            Parallel.For(0, 10000,
+            Parallel.ForEach(Enumerable.Range(0, 10000),
                 new ParallelOptions(),
                     (i) =>
                     {
                         dict1[i] = 42;
                     });
 
-            Parallel.For(0, 20000,
+            Parallel.ForEach(Enumerable.Range(0, 20000),
                     (i) =>
                     {
                         if (i < 10000)
@@ -744,14 +741,14 @@ namespace NonBlockingTests
             var updated1 = new NonBlocking.ConcurrentDictionary<int, bool>();
             var updated2 = new NonBlocking.ConcurrentDictionary<int, bool>();
 
-            Parallel.For(0, 10000,
+            Parallel.ForEach(Enumerable.Range(0, 10000),
                     (i) =>
                     {
                         dict1[i] = 42;
                     });
 
 
-            Parallel.For(0, 40000,
+            Parallel.ForEach(Enumerable.Range(0, 40000),
                     (i) =>
                     {
                         switch (i % 8)
@@ -787,7 +784,7 @@ namespace NonBlockingTests
         {
             var dict = new NonBlocking.ConcurrentDictionary<int, int>();
 
-            Parallel.For(0, 10001,
+            Parallel.ForEach(Enumerable.Range(0, 10001),
                 (i) =>
                 {
                     if (i % 2 == 0)
@@ -838,7 +835,7 @@ namespace NonBlockingTests
         {
             var dict = new NonBlocking.ConcurrentDictionary<object, int>();
 
-            Parallel.For(0, 10001,
+            Parallel.ForEach(Enumerable.Range(0, 10001),
                 (i) =>
                 {
                     if (i % 2 == 0)
@@ -889,7 +886,7 @@ namespace NonBlockingTests
         {
             var dict = new NonBlocking.ConcurrentDictionary<S1, int>();
 
-            Parallel.For(0, 10001,
+            Parallel.ForEach(Enumerable.Range(0, 10001),
                 (i) =>
                 {
                     if (i % 2 == 0)
@@ -943,7 +940,7 @@ namespace NonBlockingTests
             var keys = new string[30000];
             for (int i = 0; i < keys.Length; i++) keys[i] = i.ToString();
 
-            Parallel.For(0, 10001,
+            Parallel.ForEach(Enumerable.Range(0, 10001),
                 (i) =>
                 {
                     if (i % 2 == 0)


### PR DESCRIPTION
By the time we reach `_keyComparer.Equals(key.Value, entryKey.Value)` in `TryClaimSlotForPut/Copy` where `entryKey` is `ref Box<TKey>`, the reference might have been changed, leading to catching null reference exception or observing wrong value. Solve this by passing initially dereferenced `entryKeyValue` instead, as was probably intended in the first place. Fix this for number primitive implementations too.

Additionally:
- Speed up tests by using Parallel.For over Parallel.ForEach(enumerable)
- Slow down tests back by increasing concurrent iterations count for reliability, reduce code duplication
- Fix CLI builds by removing IsTrimmable, dotnet sdk seems to have gotten unhappy about it when targeting NS2.0 or 2.1
- Do not cache typeof(TValue).IsValueType because it is a JIT constant
- Remove TC off from builds, it has never really been an issue with default configuration and JIT can now do either OSR or classic TC when there is no loop, enable DynamicPGO too

Fixes https://github.com/neon-sunset/fast-cache/issues/52